### PR TITLE
Focus and show main window on a keypress

### DIFF
--- a/src/main.dev.ts
+++ b/src/main.dev.ts
@@ -112,6 +112,7 @@ const createWindow = async () => {
     if (process.platform !== 'darwin') {
       app.quit();
     }
+    globalShortcut.unregisterAll();
   });
 
   const menuBuilder = new MenuBuilder(mainWindow);
@@ -138,17 +139,18 @@ app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') {
     app.quit();
   }
+  globalShortcut.unregisterAll();
 });
 
 app
   .whenReady()
+  .then(createWindow)
   .then(() => {
     globalShortcut.register('CommandOrControl+O', () => {
       mainWindow.show();
     });
     return mainWindow;
   })
-  .then(createWindow)
   .catch(console.log);
 
 app.on('activate', () => {

--- a/src/main.dev.ts
+++ b/src/main.dev.ts
@@ -147,7 +147,17 @@ app
   .then(createWindow)
   .then(() => {
     globalShortcut.register('CommandOrControl+O', () => {
-      mainWindow.show();
+      if (mainWindow?.isFocused()) {
+        // Minimizing the window in a Windows OS returns focus to the original app
+        // while hiding the app in a unix like OS returns focus
+        if (process.platform === 'win32') {
+          mainWindow?.minimize();
+        } else {
+          mainWindow?.hide();
+        }
+      } else {
+        mainWindow?.show();
+      }
     });
     return mainWindow;
   })

--- a/src/main.dev.ts
+++ b/src/main.dev.ts
@@ -11,7 +11,7 @@
 import 'core-js/stable';
 import 'regenerator-runtime/runtime';
 import path from 'path';
-import { app, BrowserWindow, shell } from 'electron';
+import { app, BrowserWindow, shell, globalShortcut } from 'electron';
 import { autoUpdater } from 'electron-updater';
 import log from 'electron-log';
 import MenuBuilder from './menu';
@@ -140,7 +140,16 @@ app.on('window-all-closed', () => {
   }
 });
 
-app.whenReady().then(createWindow).catch(console.log);
+app
+  .whenReady()
+  .then(() => {
+    globalShortcut.register('CommandOrControl+O', () => {
+      mainWindow.show();
+    });
+    return mainWindow;
+  })
+  .then(createWindow)
+  .catch(console.log);
 
 app.on('activate', () => {
   // On macOS it's common to re-create a window in the app when the


### PR DESCRIPTION
This work simply registers a callback when building the main window to focus and show the window on a global keypress. The main text input is already set to `autofocus` and should allow input after focus. Currently bound to CMD/Ctrl + O.