### PR TITLE
Separate submitted phrases into their own components

### DIFF
--- a/src/components/OBS.tsx
+++ b/src/components/OBS.tsx
@@ -25,6 +25,9 @@ const useStyles = makeStyles(() =>
       fontSize: '3rem',
       textAlign: 'center',
     },
+    span: {
+      display: 'block',
+    },
   })
 );
 // eslint-disable-next-line react/display-name
@@ -88,7 +91,12 @@ function SpeechPhrase(props: any) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  return <SpeechDisplay ref={speechDisplay} />;
+  const classes = useStyles();
+  return (
+    <div className={classes.span}>
+      <SpeechDisplay ref={speechDisplay} />
+    </div>
+  );
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/components/OBS.tsx
+++ b/src/components/OBS.tsx
@@ -35,6 +35,17 @@ const SpeechDisplay = React.forwardRef<HTMLSpanElement>((_props, ref) => {
   return <span ref={ref} />;
 });
 
+function uniqueHash() {
+  const alpha =
+    '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+  const length = 8;
+  let rtn = '';
+  for (let i = 0; i < length; i += 1) {
+    rtn += alpha.charAt(Math.floor(Math.random() * alpha.length));
+  }
+  return rtn;
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function SpeechPhrase(props: any) {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -118,7 +129,8 @@ export default function OBS() {
   useEffect(() => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ipc.on('speech', (_event: any, message: any) => {
-      dispatch({ type: 'push', phrase: { message } });
+      const key: string = uniqueHash();
+      dispatch({ type: 'push', phrase: { message, key } });
     });
   }, []);
 
@@ -128,10 +140,9 @@ export default function OBS() {
       <title>Oratio - OBS</title>
       <div className={classes.titlebar} />
       <div className={classes.text}>
-        {state.phrases.map((phrase: { message: string }) => (
+        {state.phrases.map((phrase: { message: string; key: string }) => (
           <SpeechPhrase
-            // TODO: causes issues if the message is the same
-            key={phrase.message}
+            key={phrase.key}
             message={phrase.message}
             dispatch={dispatch}
           />

--- a/src/components/OBS.tsx
+++ b/src/components/OBS.tsx
@@ -5,6 +5,8 @@ import { Howl } from 'howler';
 
 const ipc = require('electron').ipcRenderer;
 
+const DEFAULT_TIMEOUT = 4000;
+
 const useStyles = makeStyles(() =>
   createStyles({
     root: {
@@ -62,6 +64,10 @@ function SpeechPhrase(props: any) {
     src: [`../assets/sounds/${soundFileName}`],
     volume: parseFloat(localStorage.getItem('volume') || '50') / 100,
   });
+  const timeBetweenChars: number = 150 - speed;
+
+  // Account for the time to print a message so it doesn't disappear early
+  const timeout: number = message.length * timeBetweenChars + DEFAULT_TIMEOUT;
 
   useEffect(() => {
     speechDisplay.current.style.fontSize = fontSize;
@@ -84,7 +90,7 @@ function SpeechPhrase(props: any) {
         }
         // eslint-disable-next-line no-plusplus
         i++;
-        setTimeout(typewriter, 150 - speed);
+        setTimeout(typewriter, timeBetweenChars);
       } else {
         setTimeout(() => {
           // TODO: the reference object is initialized as null but sometimes comes
@@ -94,7 +100,7 @@ function SpeechPhrase(props: any) {
             speechDisplay.current.innerHTML = '';
           }
           props.dispatch({ type: 'shift' });
-        }, 4000);
+        }, timeout);
       }
     };
     setTimeout(typewriter, 0);


### PR DESCRIPTION
This work refactors the main obs handler to create separate elements for each submitted phrase in a sort of rudimentary queue fashion . This allows for different timeouts and blocking style for each phrase and changes the timeouts for messages depending on their length.

This should address issues with overlapping and disappearing text and improves the outlook for quick back to back messages.

