### PR TITLE
Set file asset path based on build

### DIFF
--- a/src/components/settings/AudioSelector.tsx
+++ b/src/components/settings/AudioSelector.tsx
@@ -19,7 +19,11 @@ const useStyles = makeStyles(() =>
 );
 
 const options: string[] = [];
-fs.readdir('assets/sounds', (err: Error, files: string[]) => {
+const assetLoc =
+  process.env.NODE_ENV === 'development'
+    ? 'assets/sounds'
+    : 'resources/assets/sounds';
+fs.readdir(assetLoc, (err: Error, files: string[]) => {
   if (err) {
     throw err;
   }


### PR DESCRIPTION
The production build for windows places the sounds assets in another location. This simply specifies where the audio selector should look for audio files to fix a bug.

To test:
* Pull into dev environment and run `yarn start` and verify audio files are available on dropdown.
* Pull repo onto a windows os, run `yarn postinstall; yarn build; yarn electron-builder --win;` then install from `./releases`. Verify audio files are available on dropdown.