### PR TITLE
Make precommit auto-format .tsx

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [
-      "cross-env NODE_ENV=development eslint --cache"
+      "cross-env NODE_ENV=development eslint --cache --fix"
     ],
     "{*.json,.{babelrc,eslintrc,prettierrc}}": [
       "prettier --ignore-path .eslintignore --parser json --write"


### PR DESCRIPTION
Adresses: https://github.com/Y0dax/Oratio/issues/142

If it were to fix the minor styling problems it finds, I would find it a lot less painful to use when doing pre-commits.