### PR TITLE
Ignore warnings about plugin-proposal-private-methods

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -42,7 +42,6 @@ module.exports = (api) => {
         { loose: false },
       ],
       require('@babel/plugin-proposal-do-expressions'),
-
       // Stage 2
       [require('@babel/plugin-proposal-decorators'), { legacy: true }],
       require('@babel/plugin-proposal-function-sent'),
@@ -51,6 +50,7 @@ module.exports = (api) => {
       require('@babel/plugin-proposal-throw-expressions'),
 
       // Stage 3
+      [require("@babel/plugin-proposal-private-methods"), { loose: true }],
       require('@babel/plugin-syntax-dynamic-import'),
       require('@babel/plugin-syntax-import-meta'),
       [require('@babel/plugin-proposal-class-properties'), { loose: true }],

--- a/babel.config.js
+++ b/babel.config.js
@@ -50,7 +50,7 @@ module.exports = (api) => {
       require('@babel/plugin-proposal-throw-expressions'),
 
       // Stage 3
-      [require("@babel/plugin-proposal-private-methods"), { loose: true }],
+      [require('@babel/plugin-proposal-private-methods'), { loose: true }],
       require('@babel/plugin-syntax-dynamic-import'),
       require('@babel/plugin-syntax-import-meta'),
       [require('@babel/plugin-proposal-class-properties'), { loose: true }],


### PR DESCRIPTION
This addresses https://github.com/Y0dax/Oratio/issues/144 by silencing that warning.
Is that the right thing to do compared to fixing some underlying code? I haven't figured that out.